### PR TITLE
fix: added cookies access to some http service methods, added proxy

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -70,6 +70,10 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "move-safe:build",
+            "proxyConfig": "src/proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "browserTarget": "help-app:build:production"

--- a/src/app/services/http-req.service.ts
+++ b/src/app/services/http-req.service.ts
@@ -6,10 +6,10 @@ export class httpService {
   constructor(private http: HttpClient) {}
 
   login(login: string, password: string) {
-    return this.http.post('http://127.0.0.1:4400/api/login', {
+    return this.http.post('/api/login', {
       username: login,
       password: password,
-    });
+    }, { withCredentials: true });
   }
 
   register(login: string, password: string, phone: string) {
@@ -19,9 +19,9 @@ export class httpService {
   }
 
   addPost(title: string, content: string) {
-    return this.http.post('http://127.0.0.1:4400/api/posts/create', {
+    return this.http.post('/api/posts/create', {
       title,
       content,
-    });
+    }, { withCredentials: true });
   }
 }

--- a/src/proxy.conf.json
+++ b/src/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+    "/api/*": {
+        "target": "http://localhost:4400",
+        "secure": false,
+        "logLevel": "debug"
+    }
+}


### PR DESCRIPTION
Nie wiem kto wpadł na taki pomysł, ale w angularze ten http client domyślnie ignoruje header `Set-Cookie`, który dostaje w odpowiedzi od serwera. Sesja jest przechowywana w pliku cookie, dlatego po zalogowaniu, sesja nie była zapisywana, więc user nie był zalogowany.

Żeby przy request zapisywał i wysyłał do serwera cookies, trzeba dodać opcje: `{ withCredentials: true }`, więc trzeba to pisać przy każdym endpointcie, który wymaga autoryzacji.

Potem był jeszcze problem z CORS, więc dodałem [proxy](https://github.com/Adask023/module-landing-page/compare/main...wblazej:module-landing-page:cookies-storing-fix?expand=1#diff-c7cc7a5cedb13a06d3dc92328331fd8c983421f613ef44ad93fe7b440cf878b9) i teraz zamiast pisać całego url'a (`http://127.0.0.1:4400/api/login`), trzeba pisać tylko `/api/login`. Wszystkie route'y `/api/*` będą kierowane do API.